### PR TITLE
Versão 1.2.11.0

### DIFF
--- a/assijus-chrome-extension-setup/Product.wxs
+++ b/assijus-chrome-extension-setup/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Assijus Chrome Extension" Language="1033" Version="1.2.10.6" Manufacturer="TRF2 - Trubunal Regional Federal da 2a Regiao" UpgradeCode="fabf399a-24c0-4a38-9777-06993574075d">
+  <Product Id="*" Name="Assijus Chrome Extension" Language="1033" Version="1.2.11.0" Manufacturer="TRF2 - Trubunal Regional Federal da 2a Regiao" UpgradeCode="fabf399a-24c0-4a38-9777-06993574075d">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited" />
 
     <MajorUpgrade DowngradeErrorMessage="Uma versao mais nova de [ProductName] ja esta instalada." />

--- a/assijus-chrome-extension/Main.vb
+++ b/assijus-chrome-extension/Main.vb
@@ -70,6 +70,8 @@ Module Main
                 jsonOut = token(genericrequest.data)
             ElseIf genericrequest.url.EndsWith("/sign") Then
                 jsonOut = sign(genericrequest.data)
+            ElseIf genericrequest.url.EndsWith("/clearcurrentcert") Then
+                jsonOut = clearCurrentCertificateRequest()
             Else
                 Return "{""success"":false,""data"":{""errormsg"":""Error 404: file not found""}}"
             End If
@@ -84,14 +86,28 @@ Module Main
         End Try
     End Function
 
+    Private Function clearCurrentCertificateRequest() As String
+        Dim jsonSerializer As New JavaScriptSerializer
+        BluC.clearCurrentCertificate()
+
+        Dim genericResponse As New GenericResponse
+        genericResponse.errormsg = "OK"
+
+        Dim jsonOut As String = jsonSerializer.Serialize(genericResponse)
+
+        Return jsonOut
+
+    End Function
 
     Function test() As String
         Dim jsonSerializer As New JavaScriptSerializer
 
         Dim testresponse As New TestResponse
         testresponse.provider = "Assijus Signer Extension"
-        testresponse.version = "1.2.10.6"
+        testresponse.version = "1.2.11.0"
         testresponse.status = "OK"
+        testresponse.clearCurrentCertificateEnabled = True
+
         Dim jsonOut As String = jsonSerializer.Serialize(testresponse)
 
         Return jsonOut
@@ -237,6 +253,7 @@ Module Main
         Public version As String
         Public status As String
         Public errormsg As String
+        Public clearCurrentCertificateEnabled As Boolean
     End Class
 
 


### PR DESCRIPTION
**Adicionado Suporte ao Eject do Certificado pelo Assijus**
Implementado o Clear Current Certificate service para permitir a troca de certificados sem encerrar o browser