### PR TITLE
Corrige o algoritmo de hash na mensagem CMS

### DIFF
--- a/assijus-chrome-extension-setup/Product.wxs
+++ b/assijus-chrome-extension-setup/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Assijus Chrome Extension" Language="1033" Version="1.2.10.6" Manufacturer="TRF2 - Trubunal Regional Federal da 2a Regiao" UpgradeCode="fabf399a-24c0-4a38-9777-06993574075d">
+  <Product Id="*" Name="Assijus Chrome Extension" Language="1033" Version="1.2.10.7" Manufacturer="TRF2 - Trubunal Regional Federal da 2a Regiao" UpgradeCode="fabf399a-24c0-4a38-9777-06993574075d">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited" />
 
     <MajorUpgrade DowngradeErrorMessage="Uma versao mais nova de [ProductName] ja esta instalada." />

--- a/assijus-chrome-extension/BluC.vb
+++ b/assijus-chrome-extension/BluC.vb
@@ -106,6 +106,7 @@ Module BluC
         Dim contentInfo As ContentInfo = New ContentInfo(msg)
         Dim signedCms As SignedCms = New SignedCms(contentInfo, True)
         Dim cmsSigner As CmsSigner = New CmsSigner(signerCert)
+        cmsSigner.DigestAlgorithm = New Oid("1.3.14.3.2.26")
         signedCms.ComputeSignature(cmsSigner, False)
         Dim ab As Byte() = signedCms.Encode()
 

--- a/assijus-chrome-extension/Main.vb
+++ b/assijus-chrome-extension/Main.vb
@@ -90,7 +90,7 @@ Module Main
 
         Dim testresponse As New TestResponse
         testresponse.provider = "Assijus Signer Extension"
-        testresponse.version = "1.2.10.6"
+        testresponse.version = "1.2.10.7"
         testresponse.status = "OK"
         Dim jsonOut As String = jsonSerializer.Serialize(testresponse)
 

--- a/assijus-chrome-extension/My Project/AssemblyInfo.vb
+++ b/assijus-chrome-extension/My Project/AssemblyInfo.vb
@@ -18,7 +18,7 @@ Imports System.Runtime.InteropServices
 <Assembly: ComVisible(False)>
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM
-<Assembly: Guid("a2aa7e39-0b42-4f83-9dd8-dad2519a9f32")> 
+<Assembly: Guid("a2aa7e39-0b42-4f83-9dd8-dad2519a9f32")>
 
 ' Version information for an assembly consists of the following four values:
 '
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.0.0.0")> 
-<Assembly: AssemblyFileVersion("1.0.0.0")> 
+<Assembly: AssemblyVersion("1.2.10.7")>
+<Assembly: AssemblyFileVersion("1.2.10.7")>


### PR DESCRIPTION
O processo de assinatura pelo siga resultava em erro devido a uma falha da verificação do CMS criado pela extensão do Assijus.
O CMS enviado ao assijus estava utilizando o algoritmo SHA256 em sua mensagem (token), mas o blucservice esta validando o hash SHA1